### PR TITLE
Add initial user avatars documentation

### DIFF
--- a/docs/avatars.md
+++ b/docs/avatars.md
@@ -1,0 +1,19 @@
+# Avatar Documentation
+> This file contains user personas created for the Smart Expenses Tracker application.
+> The personas serve as a guide for understanding user needs, goals, and motivations.
+> They are intended to inform design and development decisions.
+# User Avatars (Persona) 
+
+## Emily - The Savvy Spender
+- Age: 32
+- Profession: Junior Marketing Manager
+- Goal: To understand exactly where her money goes each month and optimize her spending.
+- Pain Point: She needs a quick, automated, and insightful solution for data entry.
+- Motivation: Wants financial clarity and control.
+
+## Chris - The Budget Boss
+- Age: 29
+- Profession: Petshop Owner
+- Goal: To manage expenses efficiently and track cash flow.
+- Pain Point: He needs automated categorization to save time.
+- Motivation: Wants to reduce financial stress, ensure profitability, and maintain control over personal spending.


### PR DESCRIPTION
This PR adds the user avatars documentation, including Emily and Chris personas.  
Related to Ideation & Planning #7, as this is part of the user personas section.
